### PR TITLE
Fix fiber compilation on non x64

### DIFF
--- a/.github/workflows/compiler-support.yml
+++ b/.github/workflows/compiler-support.yml
@@ -43,11 +43,6 @@ jobs:
       ubuntu-2004_gcc-10: ${{ steps.status.outputs.ubuntu-2004_gcc-10 }}
       windows-2022_msvc17: ${{ steps.status.outputs.windows-2022_msvc17 }}
       windows-2019_msvc16: ${{ steps.status.outputs.windows-2019_msvc16 }}
-      macos-11_gcc-10: ${{ steps.status.outputs.macos-11_gcc-10 }}
-      macos-11_gcc-11: ${{ steps.status.outputs.macos-11_gcc-11 }}
-      macos-11_clang-13: ${{ steps.status.outputs.macos-11_clang-13 }}
-      macos-11_clang-14: ${{ steps.status.outputs.macos-11_clang-14 }}
-      macos-11_clang-15: ${{ steps.status.outputs.macos-11_clang-15 }}
       macos-12_gcc-11: ${{ steps.status.outputs.macos-12_gcc-11 }}
       macos-12_clang-15: ${{ steps.status.outputs.macos-12_clang-15 }}
     defaults:

--- a/.github/workflows/compiler-support.yml
+++ b/.github/workflows/compiler-support.yml
@@ -22,9 +22,6 @@ jobs:
           - { tag: "ubuntu-2004_gcc-10", name: "Ubuntu 20.04 G++ 10", cxx: "/usr/bin/g++-10", cc: "/usr/bin/gcc-10", runs-on: "ubuntu-20.04" }
           - { tag: "windows-2022_msvc17", name: "Windows Server 2022 MSVC 17", cxx: "", cc: "", runs-on: "windows-2022" }
           - { tag: "windows-2019_msvc16", name: "Windows Server 2019 MSVC 16", cxx: "", cc: "", runs-on: "windows-2019" }
-          - { tag: "macos-11_gcc-10", name: "MacOS 11 G++ 10", cxx: "g++-10", cc: "gcc-10", runs-on: "macos-11" }
-          - { tag: "macos-11_gcc-11", name: "MacOS 11 G++ 11", cxx: "g++-11", cc: "gcc-11", runs-on: "macos-11" }
-          - { tag: "macos-11_clang-15", name: "MacOS 11 Clang 15", cxx: "/usr/local/Cellar/llvm@15//15.0.7/bin/clang++", cc: "/usr/local/Cellar/llvm@15//15.0.7/bin/clang", runs-on: "macos-11" }
 #         G++11 Seems to be broken on MacOS 12 and fails with a assert inside the linker, so keep it disabled for now.
 #         - { tag: "macos-12_gcc-11", name: "MacOS 12 G++ 11", cxx: "g++-11", cc: "gcc-11", runs-on: "macos-12" }
           - { tag: "macos-12_clang-15", name: "MacOS 12 Clang 15", cxx: "/usr/local/Cellar/llvm@15//15.0.7/bin/clang++", cc: "/usr/local/Cellar/llvm@15//15.0.7/bin/clang", runs-on: "macos-12" }

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ patches and improvements for other platforms are welcome.
 Tested and supported compilers:
 | Linux                                                                 | Windows                                                             | MacOS (best effort)                                                 |
 |-----------------------------------------------------------------------|---------------------------------------------------------------------|---------------------------------------------------------------------|
-| [![ubuntu-2004_clang-10][img_ubuntu-2004_clang-10]][Compiler-Support] | [![windows-2019_msvc16][img_windows-2019_msvc16]][Compiler-Support] | [![macos-11_clang-15][img_macos-11_clang-15]][Compiler-Support]     |
-| [![ubuntu-2004_clang-11][img_ubuntu-2004_clang-11]][Compiler-Support] | [![windows-2022_msvc17][img_windows-2022_msvc17]][Compiler-Support] | [![macos-11_gcc-10][img_macos-11_gcc-10]][Compiler-Support]         |
-| [![ubuntu-2004_clang-12][img_ubuntu-2004_clang-12]][Compiler-Support] |                                                                     | [![macos-11_gcc-11][img_macos-11_gcc-11]][Compiler-Support]         |
-| [![ubuntu-2004_gcc-10][img_ubuntu-2004_gcc-10]][Compiler-Support]     |                                                                     | [![macos-12_clang-15][img_macos-12_clang-15]][Compiler-Support]     |
+| [![ubuntu-2004_clang-10][img_ubuntu-2004_clang-10]][Compiler-Support] | [![windows-2019_msvc16][img_windows-2019_msvc16]][Compiler-Support] | [![macos-12_clang-15][img_macos-12_clang-15]][Compiler-Support]     |
+| [![ubuntu-2004_clang-11][img_ubuntu-2004_clang-11]][Compiler-Support] | [![windows-2022_msvc17][img_windows-2022_msvc17]][Compiler-Support] |                                                                     |
+| [![ubuntu-2004_clang-12][img_ubuntu-2004_clang-12]][Compiler-Support] |                                                                     |                                                                     |
+| [![ubuntu-2004_gcc-10][img_ubuntu-2004_gcc-10]][Compiler-Support]     |                                                                     |                                                                     |
 | [![ubuntu-2204_clang-13][img_ubuntu-2204_clang-13]][Compiler-Support] |                                                                     |                                                                     |
 | [![ubuntu-2204_clang-14][img_ubuntu-2204_clang-14]][Compiler-Support] |                                                                     |                                                                     |
 | [![ubuntu-2204_clang-15][img_ubuntu-2204_clang-15]][Compiler-Support] |                                                                     |                                                                     |

--- a/include/asyncpp/fiber.h
+++ b/include/asyncpp/fiber.h
@@ -151,7 +151,7 @@ namespace asyncpp::detail {
 		};
 		static_assert(sizeof(stack_frame) == sizeof(uintptr_t) * 10);
 		sp -= sizeof(stack_frame) / sizeof(uintptr_t);
-		memset(sp, 0, reinterpret_cast<uintptr_t>(top_of_stack) - reinterpret_cast<uintptr_t>(sp));
+		memset(sp, 0, reinterpret_cast<uintptr_t>(stack.stack) - reinterpret_cast<uintptr_t>(sp));
 		auto frame = reinterpret_cast<stack_frame*>(sp);
 		frame->ret_addr = reinterpret_cast<uintptr_t>(entry_fn);
 		frame->param = reinterpret_cast<uintptr_t>(arg);
@@ -215,7 +215,7 @@ namespace asyncpp::detail {
 		static_assert(sizeof(stack_frame) == sizeof(uintptr_t) * 11);
 #endif
 		sp -= sizeof(stack_frame) / sizeof(uintptr_t);
-		memset(sp, 0, reinterpret_cast<uintptr_t>(top_of_stack) - reinterpret_cast<uintptr_t>(sp));
+		memset(sp, 0, reinterpret_cast<uintptr_t>(stack.stack) - reinterpret_cast<uintptr_t>(sp));
 		auto frame = reinterpret_cast<stack_frame*>(sp);
 		frame->ret_addr = reinterpret_cast<uintptr_t>(entry_fn);
 		frame->param = reinterpret_cast<uintptr_t>(arg);
@@ -237,7 +237,7 @@ namespace asyncpp::detail {
 		};
 		static_assert(sizeof(stack_frame) == sizeof(uintptr_t) * 22);
 		sp -= sizeof(stack_frame) / sizeof(uintptr_t);
-		memset(sp, 0, reinterpret_cast<uintptr_t>(top_of_stack) - reinterpret_cast<uintptr_t>(sp));
+		memset(sp, 0, reinterpret_cast<uintptr_t>(stack.stack) - reinterpret_cast<uintptr_t>(sp));
 		auto frame = reinterpret_cast<stack_frame*>(sp);
 		frame->ret_addr = reinterpret_cast<uintptr_t>(entry_fn);
 		frame->param = reinterpret_cast<uintptr_t>(arg);
@@ -258,7 +258,7 @@ namespace asyncpp::detail {
 		};
 		static_assert(sizeof(stack_frame) == sizeof(uintptr_t) * 18);
 		sp -= sizeof(stack_frame) / sizeof(uintptr_t);
-		memset(sp, 0, reinterpret_cast<uintptr_t>(top_of_stack) - reinterpret_cast<uintptr_t>(sp));
+		memset(sp, 0, reinterpret_cast<uintptr_t>(stack.stack) - reinterpret_cast<uintptr_t>(sp));
 		auto frame = reinterpret_cast<stack_frame*>(sp);
 		frame->ret_addr = reinterpret_cast<uintptr_t>(entry_fn);
 		frame->param = reinterpret_cast<uintptr_t>(arg);
@@ -279,7 +279,7 @@ namespace asyncpp::detail {
 		};
 		static_assert(sizeof(stack_frame) == sizeof(uintptr_t) * 42);
 		sp -= sizeof(stack_frame) / sizeof(uintptr_t);
-		memset(sp, 0, reinterpret_cast<uintptr_t>(top_of_stack) - reinterpret_cast<uintptr_t>(sp));
+		memset(sp, 0, reinterpret_cast<uintptr_t>(stack.stack) - reinterpret_cast<uintptr_t>(sp));
 		auto frame = reinterpret_cast<stack_frame*>(sp);
 		// Note: On PPC a function has two entry points for local and global entry respectively
 		// 		 Since we get the global entry point we also need to set the r12 register to the

--- a/include/asyncpp/ptr_tag.h
+++ b/include/asyncpp/ptr_tag.h
@@ -127,7 +127,7 @@ namespace asyncpp {
 	template<typename T1, typename... TExtra>
 	constexpr size_t min_alignof() noexcept {
 		if constexpr (sizeof...(TExtra) > 0)
-			return std::min(alignof(T1), min_alignof<TExtra...>());
+			return (std::min)(alignof(T1), min_alignof<TExtra...>());
 		else
 			return alignof(T1);
 	}

--- a/include/asyncpp/timer.h
+++ b/include/asyncpp/timer.h
@@ -333,9 +333,9 @@ namespace asyncpp {
 				}
 				now = std::chrono::steady_clock::now();
 				std::chrono::nanoseconds timeout{500 * 1000 * 1000};
-				if (!m_scheduled_set.empty()) timeout = std::min(m_scheduled_set.begin()->timepoint - now, timeout);
+				if (!m_scheduled_set.empty()) timeout = (std::min)(m_scheduled_set.begin()->timepoint - now, timeout);
 				if (!m_scheduled_cancellable_set.empty())
-					timeout = std::min(m_scheduled_cancellable_set.begin()->timepoint - now, timeout);
+					timeout = (std::min)(m_scheduled_cancellable_set.begin()->timepoint - now, timeout);
 				if (m_pushed.empty() && timeout.count() > 0) {
 					if (m_exit) break;
 					m_cv.wait_for(lck, timeout);

--- a/test/fiber.cpp
+++ b/test/fiber.cpp
@@ -1,8 +1,8 @@
-#include "asyncpp/defer.h"
-#include "asyncpp/launch.h"
-#include "asyncpp/task.h"
-#include "asyncpp/timer.h"
+#include <asyncpp/defer.h>
 #include <asyncpp/fiber.h>
+#include <asyncpp/launch.h>
+#include <asyncpp/task.h>
+#include <asyncpp/timer.h>
 #include <gtest/gtest.h>
 
 using namespace asyncpp::detail;


### PR DESCRIPTION
Compilation of fiber on non x64 was broken because of a renamed variable.