### PR TITLE
Add install of headers and cmake config scripts.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,13 +29,13 @@ jobs:
           wget ${{ env.CMAKE_URL }}
           chmod +x cmake-${{ env.CMAKE_VERSION }}-Linux-x86_64.sh
           ./cmake-${{ env.CMAKE_VERSION }}-Linux-x86_64.sh --skip-license
-      - name: Build Tests
+      - name: Build & Install
         run: |
-          mkdir build
-          cd build
-          cmake .. -DASYNCPP_BUILD_TEST=ON -G 'Unix Makefiles'
-          cmake --build .
-      - name: Run Tests
+          cmake -S . -B build -D ASYNCPP_BUILD_TEST=OFF
+          cmake --build build
+          ctest --install build --prefix install
+      - name: Run Tests 
         run: |
-          cd build
-          ./asyncpp-test
+          cmake -S test -B test_build -D CMAKE_PREFIX_PATH=../install
+          cmake --build test_build
+          ctest --test-dir test_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,44 @@
 cmake_minimum_required(VERSION 3.15)
 
 project(Asyncpp)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
 find_package(Threads REQUIRED)
 
 option(ASYNCPP_BUILD_TEST "Enable test builds" ON)
 option(ASYNCPP_BUILD_DOCS "Enable test builds" OFF)
-option(ASYNCPP_WITH_ASAN "Enable asan for test builds" ON)
-option(ASYNCPP_WITH_TSAN "Enable tsan for test builds" OFF)
 option(ASYNCPP_SO_COMPAT "Enable shared object compatibility mode" OFF)
 
 add_library(asyncpp INTERFACE)
 target_link_libraries(asyncpp INTERFACE Threads::Threads)
-target_include_directories(asyncpp
-                           INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+file(GLOB_RECURSE ASYNCPP_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/include/asyncpp/*.h)
+target_sources(asyncpp INTERFACE FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include FILES ${ASYNCPP_SOURCES})
 target_compile_features(asyncpp INTERFACE cxx_std_20)
+
 if(ASYNCPP_SO_COMPAT)
   target_compile_definitions(asyncpp INTERFACE ASYNCPP_SO_COMPAT)
 endif()
 
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/asyncpp-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/asyncpp-config.cmake
+  INSTALL_DESTINATION lib/cmake/asyncpp
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR)
+
+install(TARGETS asyncpp
+        EXPORT asyncpp-targets
+        FILE_SET HEADERS DESTINATION include
+        INCLUDES DESTINATION include)
+
+install(EXPORT asyncpp-targets
+        NAMESPACE asyncpp::
+        DESTINATION lib/cmake/asyncpp)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/asyncpp-config.cmake
+        DESTINATION lib/cmake/asyncpp)
+      
 # G++ below 11 needs a flag
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.0")
@@ -25,85 +46,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 endif()
 if(APPLE)
-  target_compile_definitions(asyncpp INTERFACE -D_XOPEN_SOURCE=600)
+  target_compile_definitions(asyncpp INTERFACE _XOPEN_SOURCE=600)
 endif()
 
 if(ASYNCPP_BUILD_TEST)
-  enable_testing()
-  include(GoogleTest)
-  if(HUNTER_ENABLED)
-    hunter_add_package(GTest)
-    find_package(GTest CONFIG REQUIRED)
-  else()
-    include(FetchContent)
-    FetchContent_Declare(
-      googletest
-      GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG v1.14.0)
-    if(WIN32)
-      set(gtest_force_shared_crt
-          ON
-          CACHE BOOL "" FORCE)
-      set(BUILD_GMOCK
-          OFF
-          CACHE BOOL "" FORCE)
-    endif()
-    FetchContent_MakeAvailable(googletest)
-  endif()
-
-  add_executable(
-    asyncpp-test
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/async_generator.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/channel.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/defer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/event.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/fiber.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/fire_and_forget.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/generator.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/launch.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/mutex.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/promise.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/ptr_tag.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/ref.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/scope_guard.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/signal.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/so_compat.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/task.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/thread_pool.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/timer.cpp)
-  target_link_libraries(asyncpp-test PRIVATE asyncpp GTest::gtest
-                                             GTest::gtest_main Threads::Threads)
-
-  if(ASYNCPP_WITH_ASAN)
-    message(STATUS "Building with asan enabled")
-    if(MSVC)
-      target_compile_options(asyncpp-test PRIVATE -fsanitize=address /Zi)
-      target_compile_definitions(asyncpp-test
-                                 PRIVATE _DISABLE_VECTOR_ANNOTATION)
-      target_compile_definitions(asyncpp-test
-                                 PRIVATE _DISABLE_STRING_ANNOTATION)
-      target_link_libraries(asyncpp-test PRIVATE libsancov.lib)
-    else()
-      target_compile_options(asyncpp-test PRIVATE -fsanitize=address)
-      target_link_libraries(asyncpp-test PRIVATE asan)
-    endif()
-  endif()
-  if(ASYNCPP_WITH_TSAN)
-    message(STATUS "Building with tsan enabled")
-    if(MSVC)
-      target_compile_options(asyncpp-test PRIVATE -fsanitize=thread /Zi)
-      target_compile_definitions(asyncpp-test
-                                 PRIVATE _DISABLE_VECTOR_ANNOTATION)
-      target_compile_definitions(asyncpp-test
-                                 PRIVATE _DISABLE_STRING_ANNOTATION)
-      target_link_libraries(asyncpp-test PRIVATE libsancov.lib)
-    else()
-      target_compile_options(asyncpp-test PRIVATE -fsanitize=thread)
-      target_link_libraries(asyncpp-test PRIVATE tsan)
-    endif()
-  endif()
-
-  gtest_discover_tests(asyncpp-test)
+  add_subdirectory(test)
 endif()
 
 if(ASYNCPP_BUILD_DOCS)

--- a/cmake/asyncpp-config.cmake.in
+++ b/cmake/asyncpp-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/asyncpp-targets.cmake)
+
+check_required_components(asyncpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,93 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(Asyncpp-tests)
+
+option(ASYNCPP_WITH_ASAN "Enable asan for test builds" ON)
+option(ASYNCPP_WITH_TSAN "Enable tsan for test builds" OFF)
+
+enable_testing()
+include(GoogleTest)
+
+find_package(Threads REQUIRED)
+
+if(HUNTER_ENABLED)
+  hunter_add_package(GTest)
+  find_package(GTest CONFIG REQUIRED)
+else()
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.14.0)
+  if(WIN32)
+    set(gtest_force_shared_crt
+        ON
+        CACHE BOOL "" FORCE)
+    set(BUILD_GMOCK
+        OFF
+        CACHE BOOL "" FORCE)
+  endif()
+  FetchContent_MakeAvailable(googletest)
+endif()
+
+add_executable(
+  asyncpp-test
+  ${CMAKE_CURRENT_SOURCE_DIR}/async_generator.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/channel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/defer.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/event.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/fiber.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/fire_and_forget.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/generator.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/launch.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/mutex.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/promise.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ptr_tag.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ref.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/scope_guard.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/signal.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/so_compat.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/task.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/thread_pool.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/timer.cpp)
+
+if (NOT ASYNCPP_BUILD_TEST)
+  find_package(asyncpp CONFIG REQUIRED)
+  target_link_libraries(asyncpp-test PRIVATE asyncpp::asyncpp)
+else()
+  target_link_libraries(asyncpp-test PRIVATE asyncpp)
+endif()
+
+target_link_libraries(asyncpp-test PRIVATE GTest::gtest GTest::gtest_main Threads::Threads)
+
+if(ASYNCPP_WITH_ASAN)
+  message(STATUS "Building with asan enabled")
+  if(MSVC)
+    target_compile_options(asyncpp-test PRIVATE -fsanitize=address /Zi)
+    target_compile_definitions(asyncpp-test
+                               PRIVATE _DISABLE_VECTOR_ANNOTATION)
+    target_compile_definitions(asyncpp-test
+                               PRIVATE _DISABLE_STRING_ANNOTATION)
+    target_link_libraries(asyncpp-test PRIVATE libsancov.lib)
+  else()
+    target_compile_options(asyncpp-test PRIVATE -fsanitize=address)
+    target_link_libraries(asyncpp-test PRIVATE asan)
+  endif()
+endif()
+
+if(ASYNCPP_WITH_TSAN)
+  message(STATUS "Building with tsan enabled")
+  if(MSVC)
+    target_compile_options(asyncpp-test PRIVATE -fsanitize=thread /Zi)
+    target_compile_definitions(asyncpp-test
+                               PRIVATE _DISABLE_VECTOR_ANNOTATION)
+    target_compile_definitions(asyncpp-test
+                               PRIVATE _DISABLE_STRING_ANNOTATION)
+    target_link_libraries(asyncpp-test PRIVATE libsancov.lib)
+  else()
+    target_compile_options(asyncpp-test PRIVATE -fsanitize=thread)
+    target_link_libraries(asyncpp-test PRIVATE tsan)
+  endif()
+endif()
+
+gtest_discover_tests(asyncpp-test)


### PR DESCRIPTION
The facilitate the install, replace `target_include_directories` with the more modern `target_sources(... FILE_SET HEADERS ...)`. The caveat is that we have to list the header files. This is made with `file(GLOB ... CONFIGURE_DEPENDS)` to ensure cmake re-configures when a header is added or removed.

The change of the github worlflow is to install `asyncpp` locally first, and run the tests from the installed version instead of using the sources directly. 