### PR TITLE
Make sure the tests are run in the Compile Compat workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,4 +38,4 @@ jobs:
         run: |
           cmake -S test -B test_build -D CMAKE_PREFIX_PATH=../install
           cmake --build test_build
-          ctest --test-dir test_build
+          ctest --test-dir test_build --no-tests=error

--- a/.github/workflows/compiler-support.yml
+++ b/.github/workflows/compiler-support.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Build
         run: cmake --build build --config Debug
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build/test --output-on-failure --no-tests=error
       - name: Update Result
         id: status
         if: ${{ always() }}


### PR DESCRIPTION
Now that the tests are being made independent from the main CMakeLists, the test dir is `build/test` instead of `build` when building from the main project. This PR also updates the ctest command to make sure running no tests is an error and not ignored.